### PR TITLE
Unpin Listen version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ end
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
-  gem 'listen', '~> 3.0.5'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,6 @@ DEPENDENCIES
   inherited_resources!
   jbuilder (~> 2.5)
   jquery-rails
-  listen (~> 3.0.5)
   paper_trail (~> 5.2.0)
   pg (~> 0.18)
   puma (~> 3.0)


### PR DESCRIPTION
Only pinned to 3.0.x for Ruby < 2.2 support; not needed since we're using Ruby 2.3.